### PR TITLE
Introducing AdminReport model

### DIFF
--- a/activeadmin_async_exporter.gemspec
+++ b/activeadmin_async_exporter.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.email       = 'franco@rootstrap.com'
   s.homepage    = 'https://rubygems.org/gems/activeadmin_async_exporter'
   s.license     = 'MIT'
-  s.files       = Dir['lib/**/*.rb']
+  s.files       = Dir['lib/**/*.{rb,tt}']
 end

--- a/lib/activeadmin_async_exporter.rb
+++ b/lib/activeadmin_async_exporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'activeadmin_async_exporter/models/admin_report'
+
 module ActiveadminAsyncExporter
   class << self
   end

--- a/lib/activeadmin_async_exporter/models/admin_report.rb
+++ b/lib/activeadmin_async_exporter/models/admin_report.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ActiveadminAsyncExporter
+  module Models
+    class AdminReport < ActiveRecord::Base
+    end
+  end
+end

--- a/lib/generators/activeadmin_async_exporter/install_generator.rb
+++ b/lib/generators/activeadmin_async_exporter/install_generator.rb
@@ -9,7 +9,11 @@ module ActiveadminAsyncExporter
     source_root File.join(__dir__, 'templates')
 
     def create_admin_reports_migration
-      migration_template 'migration.rb', 'db/migrate/add_admin_reports.rb', migration_version: migration_version
+      migration_template(
+        'migration.rb',
+        'db/migrate/add_admin_reports.rb',
+        migration_version: migration_version
+      )
     end
 
     private

--- a/lib/generators/activeadmin_async_exporter/install_generator.rb
+++ b/lib/generators/activeadmin_async_exporter/install_generator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails/generators/active_record'
+
+module ActiveadminAsyncExporter
+  class InstallGenerator < Rails::Generators::Base
+    include ActiveRecord::Generators::Migration
+
+    source_root File.join(__dir__, 'templates')
+
+    def create_admin_reports_migration
+      migration_template 'migration.rb', 'db/migrate/add_admin_reports.rb', migration_version: migration_version
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+  end
+end

--- a/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
@@ -1,0 +1,14 @@
+class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :admin_reports do |t|
+      t.references :user, index: true
+
+      t.string :entity, null: false
+      t.string :format, null: false, default: :csv
+      t.string :status, null: false
+      t.string :location_url
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
@@ -2,7 +2,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
   def change
     create_table :admin_reports do |t|
       t.references :user, index: true
-
       t.string :entity, null: false
       t.string :format, null: false, default: :csv
       t.string :status, null: false


### PR DESCRIPTION
This changeset adds an `AdminReport` model to (eventually) be able to easily manage async-generated reports from a dashboard. It holds its owner (the user who enqueued the report), which entity was exported, its location URL (could be missing if the report is still running), format, and status.

I've also added a custom generator in order to create the needed migrations at installation time.

Comments ands commits welcome!

