### PR TITLE
Configure the user model for admin reports

### DIFF
--- a/lib/activeadmin_async_exporter/models/admin_report.rb
+++ b/lib/activeadmin_async_exporter/models/admin_report.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module ActiveadminAsyncExporter
-  module Models
-    class AdminReport < ActiveRecord::Base
-    end
-  end
-end

--- a/lib/activeadmin_async_exporter/reports/dsl.rb
+++ b/lib/activeadmin_async_exporter/reports/dsl.rb
@@ -17,7 +17,9 @@ module ActiveadminAsyncExporter
             decorate_model: decorate_model,
             query: params['q']
           }
+
           ActiveadminAsyncExporter::Worker.perform_async(options)
+
           redirect_to(action: :index)
         end
       end

--- a/lib/activeadmin_async_exporter/reports/worker.rb
+++ b/lib/activeadmin_async_exporter/reports/worker.rb
@@ -34,6 +34,7 @@ module ActiveadminAsyncExporter
       collection(controller, options).find_in_batches do |group|
         group.each do |m|
           m = m.decorate if options['decorate_model']
+
           csv << evaluators.collect { |ev| m.send(ev) }
         end
       end

--- a/lib/generators/activeadmin_async_exporter/install_generator.rb
+++ b/lib/generators/activeadmin_async_exporter/install_generator.rb
@@ -6,20 +6,35 @@ module ActiveadminAsyncExporter
   class InstallGenerator < Rails::Generators::Base
     include ActiveRecord::Generators::Migration
 
+    argument :user_class, type: :string, default: 'User'
+
     source_root File.join(__dir__, 'templates')
+
+    def configure
+      create_admin_reports_migration
+      create_admin_reports_model
+    end
+
+    private
 
     def create_admin_reports_migration
       migration_template(
         'migration.rb',
         'db/migrate/add_admin_reports.rb',
-        migration_version: migration_version
+        user_class_name: user_class_name
       )
     end
 
-    private
+    def create_admin_reports_model
+      template(
+        'admin_report.rb',
+        'app/admin/models/admin_report.rb',
+        user_class_name: user_class_name
+      )
+    end
 
-    def migration_version
-      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    def user_class_name
+      user_class.underscore.singularize
     end
   end
 end

--- a/lib/generators/activeadmin_async_exporter/templates/admin_report.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/admin_report.rb.tt
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AdminReport < ApplicationRecord
+  belongs_to :<%= user_class_name %>
+end

--- a/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
@@ -1,7 +1,8 @@
-class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :admin_reports do |t|
-      t.references :user, index: true
+      t.references :<%= user_class_name %>, index: true
+
       t.string :entity, null: false
       t.string :format, null: false, default: :csv
       t.string :status, null: false


### PR DESCRIPTION
This changeset allows to optionally configure a user class for the admin reports at install time. If nothing is passed to the generator, `User` will be used. So now you can run:

`rails generate activeadmin_async_exporter:install SuperAdminUser`

and `AdminReport`s will be associated to `SuperAdminUser`s. 

I'm open to better options, so comments and commits are welcome!