### PR TITLE
Create AdminReport instance

### DIFF
--- a/activeadmin_async_exporter.gemspec
+++ b/activeadmin_async_exporter.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.date        = '2019-10-09'
   s.summary     = 'Async exporter for Active Admin using Sidekiq'
   s.description = s.summary
-  s.authors     = ['Franco Pariani']
+  s.authors     = ['Franco Pariani', 'Horacio Bertorello']
   s.email       = 'franco@rootstrap.com'
   s.homepage    = 'https://rubygems.org/gems/activeadmin_async_exporter'
   s.license     = 'MIT'

--- a/lib/activeadmin_async_exporter.rb
+++ b/lib/activeadmin_async_exporter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
 require 'activeadmin_async_exporter'
-require 'activeadmin_async_exporter/models/admin_report'
 require 'activeadmin_async_exporter/reports/dsl'
 require 'activeadmin_async_exporter/reports/worker'
 

--- a/lib/activeadmin_async_exporter/reports/dsl.rb
+++ b/lib/activeadmin_async_exporter/reports/dsl.rb
@@ -6,12 +6,19 @@ module ActiveadminAsyncExporter
       def csv_report(columns:, decorate_model: false)
         action_item :download_csv, only: :index do
           link_to 'Download CSV',
-                  { action: :download_csv, params: params },
+                  { action: :download_csv, params: params.to_enum.to_h },
                   method: :post, data: { confirm: 'Are you sure you want to generate this report?' }
         end
 
         collection_action :download_csv, method: :post do
+          admin_report = AdminReport.create!(
+            author_id: current_admin_user.id,
+            entity: current_collection.name,
+            status: :pending
+          )
+
           options = {
+            admin_report_id: admin_report.id,
             controller: self.class.name,
             columns: columns,
             decorate_model: decorate_model,
@@ -19,8 +26,13 @@ module ActiveadminAsyncExporter
           }
 
           ActiveadminAsyncExporter::Worker.perform_async(options)
+          redirect_to admin_admin_report_path(admin_report)
+        end
 
-          redirect_to(action: :index)
+        controller do
+          def current_collection
+            scoped_collection
+          end
         end
       end
     end

--- a/lib/activeadmin_async_exporter/reports/worker.rb
+++ b/lib/activeadmin_async_exporter/reports/worker.rb
@@ -13,16 +13,18 @@ module ActiveadminAsyncExporter
       CSV.open(path, 'wb', headers: true) do |csv|
         build_csv(csv, columns, controller, options)
       end
+
+      AdminReport.find(options['admin_report_id']).update_attributes(status: :ready)
     end
 
     private
 
     def collection(controller, options)
-      controller.scoped_collection.ransack(options['query']).result
+      controller.current_collection.ransack(options['query']).result
     end
 
     def filename(controller)
-      [controller.scoped_collection.name.pluralize.downcase, Time.current.to_i].join('_') + '.csv'
+      [controller.current_collection.name.pluralize.downcase, Time.current.to_i].join('_') + '.csv'
     end
 
     def build_csv(csv, columns, controller, options)

--- a/lib/generators/activeadmin_async_exporter/install_generator.rb
+++ b/lib/generators/activeadmin_async_exporter/install_generator.rb
@@ -13,6 +13,7 @@ module ActiveadminAsyncExporter
     def configure
       create_admin_reports_migration
       create_admin_reports_model
+      create_active_admin_view
     end
 
     private
@@ -21,20 +22,31 @@ module ActiveadminAsyncExporter
       migration_template(
         'migration.rb',
         'db/migrate/add_admin_reports.rb',
-        user_class_name: user_class_name
+        user_table_name: user_table_name
       )
     end
 
     def create_admin_reports_model
       template(
         'admin_report.rb',
-        'app/admin/models/admin_report.rb',
-        user_class_name: user_class_name
+        'app/models/admin_report.rb',
+        user_class: user_class
+      )
+    end
+
+    def create_active_admin_view
+      template(
+        'admin_reports.rb',
+        'app/admin/admin_reports.rb'
       )
     end
 
     def user_class_name
       user_class.underscore.singularize
+    end
+
+    def user_table_name
+      user_class_name.pluralize
     end
   end
 end

--- a/lib/generators/activeadmin_async_exporter/templates/admin_report.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/admin_report.rb.tt
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class AdminReport < ApplicationRecord
-  belongs_to :<%= user_class_name %>
+  enum status: { pending: 0, ready: 1, error: 2 }
+
+  belongs_to :author, class_name: '<%= user_class %>'
 end

--- a/lib/generators/activeadmin_async_exporter/templates/admin_reports.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/admin_reports.rb.tt
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+require 'open-uri'
+
+ActiveAdmin.register AdminReport do
+  actions :index, :show, :destroy
+
+  filter :entity
+  filter :format
+  filter :created_at
+  filter :location_url
+
+  index do
+    id_column
+    column :author
+    column :entity
+    column :format
+    column :status
+    column :file do |report|
+      link_to 'Download CSV', download_file_admin_admin_report_path(report) if report.ready?
+    end
+    column :created_at
+
+    actions
+  end
+
+  show do
+    attributes_table_for(admin_report) do
+      row :id
+      row :author
+      row :entity
+      row :format
+      row 'Status' do
+        status_tag (admin_report.ready? ? 'green' : 'orange'), label: admin_report.status
+      end
+      row :file do
+        link_to 'Download CSV', download_file_admin_admin_report_path if admin_report.ready?
+      end
+      row :created_at
+    end
+  end
+
+  member_action :download_file, method: :get do
+    send_data(open(resource.location_url).read, disposition: 'attachment', filename: /(?!.*\/).+/.match(resource.location_url)[0])
+  end
+
+  controller do
+    def scoped_collection
+      AdminReport.includes(:author)
+    end
+  end
+end

--- a/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
+++ b/lib/generators/activeadmin_async_exporter/templates/migration.rb.tt
@@ -1,11 +1,12 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :admin_reports do |t|
-      t.references :<%= user_class_name %>, index: true
+      t.references :author
+      t.foreign_key :<%= user_table_name %>, column: :author_id, primary_key: 'id'
 
       t.string :entity, null: false
       t.string :format, null: false, default: :csv
-      t.string :status, null: false
+      t.integer :status, null: false
       t.string :location_url
 
       t.timestamps


### PR DESCRIPTION
## Introduced changes:

- Create the `AdminReport` view for the Active Admin Panel.
- Create an `AdminReport` instance when generating the new report, and redirect the user to the corresponding `show` view within the admin panel.
- Minor changes to the `AdminReport` model.