### PR TITLE
Add support for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ActiveAdmin::AsyncExporter
 
-Async exporter for Active Admin using Sidekiq.
+Async exporter for Active Admin using ActiveJob.
 
 ## Installation
 All you have to do is add the gem to your project like this:

--- a/activeadmin-async_exporter.gemspec
+++ b/activeadmin-async_exporter.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |s|
   s.name        = 'activeadmin-async_exporter'
   s.version     = ActiveAdmin::AsyncExporter::VERSION
   s.date        = '2019-10-09'
-  s.summary     = 'Async exporter for Active Admin using Sidekiq'
+  s.summary     = 'Async exporter for Active Admin using ActiveJob'
   s.description = s.summary
-  s.authors     = ['Franco Pariani', 'Horacio Bertorello']
+  s.authors     = ['Franco Pariani', 'Horacio Bertorello', 'Ricardo Cortio']
   s.email       = 'franco@rootstrap.com'
   s.homepage    = 'https://rubygems.org/gems/activeadmin-async_exporter'
   s.metadata    = { 'source_code_uri' => 'https://github.com/rootstrap/activeadmin-async_exporter' }
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activeadmin', '>= 1.0.0.pre1'
 
   s.add_dependency 'rails', '>= 1.0.0'
+  s.add_dependency 'aws-sdk-s3', '~> 1'
 
   s.add_development_dependency 'rubocop', '~> 0.75.1'
 end

--- a/lib/active_admin/async_exporter.rb
+++ b/lib/active_admin/async_exporter.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-require 'active_admin/async_exporter/version'
-require 'sidekiq/web'
 require 'active_admin'
 
+require 'active_admin/async_exporter/version'
+require 'active_admin/async_exporter/config'
 require 'active_admin/async_exporter/reports/dsl'
 require 'active_admin/async_exporter/reports/worker'
+require 'active_admin/async_exporter/services/aws_s3_service'
 
 module ActiveAdmin
   module AsyncExporter

--- a/lib/active_admin/async_exporter/config.rb
+++ b/lib/active_admin/async_exporter/config.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module AsyncExporter
+    class << self
+      def configure
+        yield config
+      end
+
+      def config
+        @config ||= Config.new
+      end
+    end
+
+    class Config
+      attr_accessor :aws_bucket_name, :aws_bucket_folder_path
+
+      def initialize
+        @aws_bucket_name = nil
+        @aws_bucket_folder_path = nil
+      end
+    end
+  end
+end

--- a/lib/active_admin/async_exporter/services/aws_s3_service.rb
+++ b/lib/active_admin/async_exporter/services/aws_s3_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module AsyncExporter
+    module Services
+      class AwsS3Service
+        attr_accessor :file, :s3, :bucket, :object
+
+        def initialize(file)
+          @file = file
+          @s3 = Aws::S3::Resource.new
+          @bucket = s3.bucket(ActiveAdmin::AsyncExporter.config.aws_bucket_name)
+        end
+
+        def store
+          @object = bucket.object(filename)
+          object.upload_file(Pathname.new(file[:path]), { acl: 'public-read' })
+          self
+        end
+
+        def url
+          object.public_url.to_s
+        end
+
+        def delete
+          bucket.delete_objects({ delete: { objects: [{ key: filename }] } })
+        end
+
+        private
+
+        def filename
+          @filename ||= "#{bucket_folder}#{file[:name]}"
+        end
+
+        def bucket_folder
+          path = ActiveAdmin::AsyncExporter.config.aws_bucket_folder_path
+          return '' unless path.present?
+
+          "#{path}/"
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/active_admin/async_exporter/config/config_generator.rb
+++ b/lib/generators/active_admin/async_exporter/config/config_generator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ActiveAdmin::AsyncExporter
+  module Generators
+    class ConfigGenerator < Rails::Generators::Base
+
+      source_root File.join(__dir__, 'templates')
+
+      def copy_config_file
+        template 'async_exporter_config.rb', 'config/initializers/activeadmin-async_exporter.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/active_admin/async_exporter/config/templates/async_exporter_config.rb.tt
+++ b/lib/generators/active_admin/async_exporter/config/templates/async_exporter_config.rb.tt
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+ActiveAdmin::AsyncExporter.configure do |config|
+  # config.aws_bucket_name = nil
+  # config.aws_bucket_folder_path = nil
+end


### PR DESCRIPTION
## Add support for AWS

- `aws-sdk-s3` dependency added.
- Ability to create the AsyncExporter initializer by running `rails g active_admin:async_exporter:config`.

Besides that, in order to use AWS S3, developers have to create the AWS initializer manually.