### PR TITLE
Change gem usage

### DIFF
--- a/lib/active_admin/async_exporter/reports/dsl.rb
+++ b/lib/active_admin/async_exporter/reports/dsl.rb
@@ -4,6 +4,22 @@ module ActiveAdmin
   module AsyncExporter
     module Reports
       module DSL
+        attr_reader :csv_fields
+
+        def csv_async(decorate_model: false)
+          @csv_fields ||= {}
+
+          yield
+
+          csv_report(columns: csv_fields, decorate_model: decorate_model)
+        end
+
+        def csv_column(column_name, column_value = nil)
+          column_value ||= column_name
+
+          csv_fields[:"#{column_name.to_sym}"] = column_value.to_sym
+        end
+
         def csv_report(columns:, decorate_model: false)
           action_item :download_csv, only: :index do
             link_to 'Download CSV',
@@ -12,6 +28,7 @@ module ActiveAdmin
           end
 
           collection_action :download_csv, method: :post do
+
             admin_report = AdminReport.create!(
               author_id: current_admin_user.id,
               entity: current_collection.name,


### PR DESCRIPTION
The idea of this PR is to change the usage of the gem, from receiving a hash to receiving blocks, it changed from:
```ruby
csv_report(columns: { email: :email, date_joined: :created_at }
```
to:
```ruby
csv_async do
  csv_column(:email)
  csv_column(:date_joined, :created_at)
end
```

The original idea of this PR was to add support for more complex methods in the form of blocks:
```ruby
csv_async do
  csv_column(:email)
  ...
  csv_column(:full_name) { |x| "#{x.first_name} #{x.last_name}"}
end
```
however, whenever we send the proc to sidekiq, we just receive a string which cannot be rendered back into a proc so we are able to use it(at least not easily, will keep looking for a way to achieve this though), so I discussed this with @fpariani and the decision was to change the usage and let the `complex methods` side of things just be handled by decorators for a v1