### PR TITLE
Allow using blocks

### DIFF
--- a/lib/active_admin/async_exporter/reports/dsl.rb
+++ b/lib/active_admin/async_exporter/reports/dsl.rb
@@ -14,10 +14,15 @@ module ActiveAdmin
           csv_report(columns: csv_fields, decorate_model: decorate_model, file_name: file_name)
         end
 
-        def csv_column(column_name, column_value = nil)
+        def csv_column(column_name, column_value = nil, &block)
           column_value ||= column_name
 
-          csv_fields[column_name.to_sym] = column_value.to_s
+          column_value = block.source if block_given?
+
+          raise ActiveAdmin::AsyncExporter::Error, 'No argument given' if block_given? &&
+                                                                          block.parameters.blank?
+
+          csv_fields[column_name.to_sym] = { block: block_given?, value: column_value.to_s }
         end
 
         def csv_report(columns:, decorate_model: false, file_name: nil)
@@ -56,5 +61,7 @@ module ActiveAdmin
         end
       end
     end
+
+    class Error < ActiveAdmin::Error; end
   end
 end


### PR DESCRIPTION
With this PR, we allow the usage of blocks to get values, for example:

```ruby
ActiveAdmin.register User do
  ...
  ...
  csv_async do
    csv_column(:hello) { |x| "Hello, my name is #{x.first_name}" }
    csv_column(:how_long) do |x|
      if x.created_at < 2.days.ago
        'I registered less than 2 days ago'
      else
        "I've been here for more than 2 days"
      end
    end
  end
end
```

Since we cannot send a proc to a job, we need to get the proc source code before and send it as a string, then parse it so we can re-build the block in the job and invoke it