### PR TITLE
Add support for local storage

### DIFF
--- a/lib/active_admin/async_exporter.rb
+++ b/lib/active_admin/async_exporter.rb
@@ -7,6 +7,7 @@ require 'active_admin/async_exporter/config'
 require 'active_admin/async_exporter/reports/dsl'
 require 'active_admin/async_exporter/reports/worker'
 require 'active_admin/async_exporter/services/storage_service'
+require 'active_admin/async_exporter/services/disk_service'
 require 'active_admin/async_exporter/services/aws_s3_service'
 
 module ActiveAdmin

--- a/lib/active_admin/async_exporter.rb
+++ b/lib/active_admin/async_exporter.rb
@@ -6,6 +6,7 @@ require 'active_admin/async_exporter/version'
 require 'active_admin/async_exporter/config'
 require 'active_admin/async_exporter/reports/dsl'
 require 'active_admin/async_exporter/reports/worker'
+require 'active_admin/async_exporter/services/storage_service'
 require 'active_admin/async_exporter/services/aws_s3_service'
 
 module ActiveAdmin

--- a/lib/active_admin/async_exporter/config.rb
+++ b/lib/active_admin/async_exporter/config.rb
@@ -13,7 +13,7 @@ module ActiveAdmin
     end
 
     class Config
-      attr_accessor :aws_bucket_name, :aws_bucket_folder_path
+      attr_accessor :service, :aws_bucket_name, :aws_bucket_folder_path
 
       def initialize
         @aws_bucket_name = nil

--- a/lib/active_admin/async_exporter/config.rb
+++ b/lib/active_admin/async_exporter/config.rb
@@ -13,11 +13,12 @@ module ActiveAdmin
     end
 
     class Config
-      attr_accessor :service, :aws_bucket_name, :aws_bucket_folder_path
+      attr_accessor :service, :aws_bucket_name, :aws_bucket_folder_path, :disk_folder_path
 
       def initialize
         @aws_bucket_name = nil
         @aws_bucket_folder_path = nil
+        @disk_folder_path = nil
       end
     end
   end

--- a/lib/active_admin/async_exporter/reports/worker.rb
+++ b/lib/active_admin/async_exporter/reports/worker.rb
@@ -14,7 +14,7 @@ module ActiveAdmin
           build_csv(csv, columns, controller, options)
         end
 
-        file = Services::AwsS3Service.new(path: path, name: file_name).store
+        file = Services::StorageService.call(path: path, name: file_name).store
         AdminReport.find(options[:admin_report_id]).update_attributes(
           status: :ready,
           location_url: file.url

--- a/lib/active_admin/async_exporter/services/disk_service.rb
+++ b/lib/active_admin/async_exporter/services/disk_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module AsyncExporter
+    module Services
+      class DiskService
+        attr_accessor :file, :folder
+
+        def initialize(file)
+          @file = file
+          @folder = ActiveAdmin::AsyncExporter.config.disk_folder_path
+        end
+
+        def store
+          make_dir
+          @object = IO.copy_stream(file[:path], filename)
+          self
+        end
+
+        def url
+          filename
+        end
+
+        def delete
+          File.delete(filename)
+        end
+
+        private
+
+        def make_dir
+          FileUtils.mkdir_p(folder)
+        end
+
+        def filename
+          @filename ||= "#{folder}/#{file[:name]}"
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/async_exporter/services/storage_service.rb
+++ b/lib/active_admin/async_exporter/services/storage_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveAdmin
+  module AsyncExporter
+    module Services
+      class StorageService
+        private_class_method :new
+
+        def self.call(*args)
+          case ActiveAdmin::AsyncExporter.config.service
+          when :amazon
+            Services::AwsS3Service.new(*args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/async_exporter/services/storage_service.rb
+++ b/lib/active_admin/async_exporter/services/storage_service.rb
@@ -10,6 +10,8 @@ module ActiveAdmin
           case ActiveAdmin::AsyncExporter.config.service
           when :amazon
             Services::AwsS3Service.new(*args)
+          else
+            Services::DiskService.new(*args)
           end
         end
       end

--- a/lib/generators/active_admin/async_exporter/config/templates/async_exporter_config.rb.tt
+++ b/lib/generators/active_admin/async_exporter/config/templates/async_exporter_config.rb.tt
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 ActiveAdmin::AsyncExporter.configure do |config|
+  ## Storage Service
+  # The available options are :local, :amazon
+  # default option: :local
+  # config.service = :local
+
+  ## AWS S3
   # config.aws_bucket_name = nil
   # config.aws_bucket_folder_path = nil
 end

--- a/lib/generators/active_admin/async_exporter/config/templates/async_exporter_config.rb.tt
+++ b/lib/generators/active_admin/async_exporter/config/templates/async_exporter_config.rb.tt
@@ -9,4 +9,7 @@ ActiveAdmin::AsyncExporter.configure do |config|
   ## AWS S3
   # config.aws_bucket_name = nil
   # config.aws_bucket_folder_path = nil
+
+  ## Disk
+  config.disk_folder_path = Rails.root.join('exporter')
 end


### PR DESCRIPTION
## Add support for local storage

* Create Storage Service: the purpose of that is creates the instance of the storage service according to the one configured in the initializer to support different cloud providers. 
  * Note: any idea about how to resolve this in another way is welcome
* Create Disk service: to save files locally and no depend on cloud service to development purposes.