### PR TITLE
Fix/change autogenerated file

### DIFF
--- a/lib/generators/active_admin/async_exporter/install/templates/admin_reports.rb.tt
+++ b/lib/generators/active_admin/async_exporter/install/templates/admin_reports.rb.tt
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 # encoding: utf-8
 
-require 'open-uri'
-
 ActiveAdmin.register AdminReport do
   actions :index, :show, :destroy
 
@@ -42,7 +40,7 @@ ActiveAdmin.register AdminReport do
   end
 
   member_action :download_file, method: :get do
-    send_data(open(resource.location_url).read, disposition: 'attachment', filename: /(?!.*\/).+/.match(resource.location_url)[0])
+    send_data(File.open(resource.location_url).read, disposition: 'attachment', filename: /(?!.*\/).+/.match(resource.location_url)[0])
   end
 
   controller do

--- a/lib/generators/active_admin/async_exporter/install/templates/admin_reports.rb.tt
+++ b/lib/generators/active_admin/async_exporter/install/templates/admin_reports.rb.tt
@@ -40,7 +40,9 @@ ActiveAdmin.register AdminReport do
   end
 
   member_action :download_file, method: :get do
-    send_data(File.open(resource.location_url).read, disposition: 'attachment', filename: /(?!.*\/).+/.match(resource.location_url)[0])
+    send_data(File.open(resource.location_url).read,
+              disposition: 'attachment',
+              filename: %r{(?!.*/).+}.match(resource.location_url)[0])
   end
 
   controller do


### PR DESCRIPTION
This PR changes the usage of `Kernel#open` to `File#open`. While adding #20 I realized that the autogenerated files used "Kernel#open" and got this error from rubocop:
`Security/Open: The use of Kernel#open is a serious security risk`.
I also remove the usage of `open-uri` since URI#open is a private method in some older versions of ruby.
Apart from this, changes that exact line of code that was 130 characters long and reformates it to follow the gem's rubocop configuration of up to 100 characters per line.